### PR TITLE
fix: use TypeScript syntax in source code

### DIFF
--- a/src/jimp.ts
+++ b/src/jimp.ts
@@ -16,4 +16,4 @@ class JIMPBUffer {
 
 globalThis.JIMPBUffer = JIMPBUffer
 
-module.exports = jimp
+export = jimp

--- a/src/jimp.ts
+++ b/src/jimp.ts
@@ -1,4 +1,4 @@
-import jimp from 'jimp/es'
+import jimp = require('jimp')
 
 class JIMPBUffer {
   constructor(data, ...args) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ES6",
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "esModuleInterop": true,
     "outDir": "dist",
     "strict": false,
     "declaration": true


### PR DESCRIPTION
Using `export = ` (which is a TypeScript thing) `tsc` will output the export itself, and we can also get correct types instead of copying the actual types file.

Diff (after running `prettier` on the generated file)

```diff
diff --git c/dist/jimp.cjs w/dist/jimp.cjs
index 6b084d2..fd6e0e7 100644
--- c/dist/jimp.cjs
+++ w/dist/jimp.cjs
@@ -31293,7 +31293,6 @@
         function (r) {
           return r && r.__esModule ? r : { default: r };
         };
-      Object.defineProperty(i, "__esModule", { value: true });
       const s = o(a(1099));
       class JIMPBUffer {
         constructor(r, ...i) {
diff --git c/dist/jimp.d.ts w/dist/jimp.d.ts
index 08877f8..cf15fc8 100644
--- c/dist/jimp.d.ts
+++ w/dist/jimp.d.ts
@@ -1,50 +1,2 @@
-/**
- * While there is nothing in these typings that prevent it from running in TS 2.8 even,
- * due to the complexity of the typings anything lower than TS 3.1 will only see
- * Jimp as `any`. In order to test the strict versions of these types in our typing
- * test suite, the version has been bumped to 3.1
- */
-
-import {
-  Jimp as JimpType,
-  Bitmap,
-  RGB,
-  RGBA,
-  UnionToIntersection,
-  GetPluginVal,
-  GetPluginConst,
-  GetPluginEncoders,
-  GetPluginDecoders,
-  JimpConstructors
-} from '@jimp/core';
-import typeFn from '@jimp/types';
-import pluginFn from '@jimp/plugins';
-
-type Types = ReturnType<typeof typeFn>;
-type Plugins = ReturnType<typeof pluginFn>;
-
-type IntersectedPluginTypes = UnionToIntersection<
-  GetPluginVal<Types> | GetPluginVal<Plugins>
->;
-
-type IntersectedPluginConsts = UnionToIntersection<
-  GetPluginConst<Types> | GetPluginConst<Plugins>
->;
-
-type IntersectedPluginEncoders = UnionToIntersection<
-  GetPluginEncoders<Types> | GetPluginEncoders<Plugins>
->;
-
-type IntersectedPluginDecoders = UnionToIntersection<
-  GetPluginDecoders<Types> | GetPluginDecoders<Plugins>
->;
-
-type Jimp = JimpType & IntersectedPluginTypes;
-
-declare const Jimp: JimpConstructors & IntersectedPluginConsts & {
-  prototype: Jimp;
-  encoders: IntersectedPluginEncoders;
-  decoders: IntersectedPluginDecoders;
-};
-
-export = Jimp;
+import jimp from 'jimp/es';
+export = jimp;
```

---

My hope is that this miiight make #42 easier as we're not copying stuff, but who knows 🙂 Regardless, it's cleaner to produce a declaration file instead of copying it